### PR TITLE
feat: delete tournament, manual fixture, create/delete series

### DIFF
--- a/src/api/Team-Event/series.ts
+++ b/src/api/Team-Event/series.ts
@@ -1,6 +1,7 @@
 import axiosInstance from "@/services/axiosConfig";
 import {
   TeamEventSeries,
+  CreateSeriesRequest,
   LoadSeriesResultRequest,
   SetLineupRequest,
   LoadMatchScoreRequest,
@@ -90,4 +91,35 @@ export const loadMatchScore = async (
     data
   );
   return response.data as TeamEventMatch;
+};
+
+export const createSeries = async (
+  eventId: number,
+  categoryId: number,
+  data: CreateSeriesRequest
+): Promise<TeamEventSeries> => {
+  const response = await axiosInstance.post(
+    basePath(eventId, categoryId),
+    data
+  );
+  return response.data as TeamEventSeries;
+};
+
+export const deleteSeries = async (
+  eventId: number,
+  categoryId: number,
+  seriesId: number
+): Promise<void> => {
+  await axiosInstance.delete(
+    `${basePath(eventId, categoryId)}/${seriesId}`
+  );
+};
+
+export const deleteFixture = async (
+  eventId: number,
+  categoryId: number
+): Promise<void> => {
+  await axiosInstance.delete(
+    `${basePath(eventId, categoryId)}/fixture`
+  );
 };

--- a/src/hooks/Team-Event/useTeamEventMutations.ts
+++ b/src/hooks/Team-Event/useTeamEventMutations.ts
@@ -20,6 +20,9 @@ import {
 } from "@/api/Team-Event/teams";
 import {
   generateFixture,
+  createSeries,
+  deleteSeries,
+  deleteFixture,
   loadSeriesResult,
   updateSeriesResult,
   setLineup,
@@ -34,6 +37,7 @@ import {
   CreateTeamRequest,
   AddPlayerRequest,
   ReplacePlayerRequest,
+  CreateSeriesRequest,
   LoadSeriesResultRequest,
   FinalizeEventRequest,
   SetLineupRequest,
@@ -214,14 +218,24 @@ export const useSeriesMutations = (eventId: number, categoryId: number) => {
 
   const generateFixtureMutation = useMutation({
     mutationFn: () => generateFixture(eventId, categoryId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: teamEventKeys.series(eventId, categoryId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: teamEventKeys.detail(eventId),
-      });
-    },
+    onSuccess: invalidate,
+  });
+
+  const createSeriesMutation = useMutation({
+    mutationFn: (data: CreateSeriesRequest) =>
+      createSeries(eventId, categoryId, data),
+    onSuccess: invalidate,
+  });
+
+  const deleteSeriesMutation = useMutation({
+    mutationFn: (seriesId: number) =>
+      deleteSeries(eventId, categoryId, seriesId),
+    onSuccess: invalidate,
+  });
+
+  const deleteFixtureMutation = useMutation({
+    mutationFn: () => deleteFixture(eventId, categoryId),
+    onSuccess: invalidate,
   });
 
   const loadResultMutation = useMutation({
@@ -272,6 +286,9 @@ export const useSeriesMutations = (eventId: number, categoryId: number) => {
 
   return {
     generateFixtureMutation,
+    createSeriesMutation,
+    deleteSeriesMutation,
+    deleteFixtureMutation,
     loadResultMutation,
     updateResultMutation,
     setLineupMutation,

--- a/src/sections/Team-Event/Admin/FixtureTab.tsx
+++ b/src/sections/Team-Event/Admin/FixtureTab.tsx
@@ -1,12 +1,24 @@
 "use client";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
 import { TeamEvent } from "@/types/Team-Event/TeamEvent";
 import { TeamEventStatus } from "@/common/enum/team-event.enum";
 import { useTeamEventSeries } from "@/hooks/Team-Event/useTeamEventSeries";
+import { useTeamEventTeams } from "@/hooks/Team-Event/useTeamEventTeams";
 import { useSeriesMutations } from "@/hooks/Team-Event/useTeamEventMutations";
 import { FixtureView } from "../FixtureView";
-import { CalendarPlus } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
 
 interface FixtureTabProps {
   event: TeamEvent;
@@ -16,17 +28,76 @@ interface FixtureTabProps {
 
 export function FixtureTab({ event, categoryId, onSeriesClick }: FixtureTabProps) {
   const { series, isLoading } = useTeamEventSeries(event.id, categoryId);
-  const { generateFixtureMutation } = useSeriesMutations(event.id, categoryId);
+  const { teams } = useTeamEventTeams(event.id, categoryId);
+  const {
+    createSeriesMutation,
+    deleteSeriesMutation,
+    deleteFixtureMutation,
+  } = useSeriesMutations(event.id, categoryId);
 
-  const canGenerate =
-    event.status !== TeamEventStatus.finished && series.length === 0;
+  const [matchday, setMatchday] = useState("1");
+  const [homeTeamId, setHomeTeamId] = useState("");
+  const [awayTeamId, setAwayTeamId] = useState("");
 
-  const handleGenerate = () => {
-    if (!confirm("¿Generar el fixture? Esta acción creará todas las jornadas."))
+  useEffect(() => {
+    setHomeTeamId("");
+    setAwayTeamId("");
+  }, [categoryId]);
+
+  const isFinished = event.status === TeamEventStatus.finished;
+
+  const handleCreateSeries = () => {
+    const md = parseInt(matchday, 10);
+    const home = parseInt(homeTeamId, 10);
+    const away = parseInt(awayTeamId, 10);
+
+    if (isNaN(md) || md < 1) {
+      toast.error("Jornada inválida");
       return;
-    generateFixtureMutation.mutate(undefined, {
-      onSuccess: () => toast.success("Fixture generado correctamente"),
-      onError: () => toast.error("Error al generar el fixture"),
+    }
+    if (isNaN(home) || isNaN(away)) {
+      toast.error("Seleccioná ambos equipos");
+      return;
+    }
+    if (home === away) {
+      toast.error("Los equipos no pueden ser el mismo");
+      return;
+    }
+
+    createSeriesMutation.mutate(
+      { homeTeamId: home, awayTeamId: away, matchday: md },
+      {
+        onSuccess: () => {
+          toast.success("Enfrentamiento creado");
+          setHomeTeamId("");
+          setAwayTeamId("");
+        },
+        onError: () => toast.error("Error al crear el enfrentamiento"),
+      }
+    );
+  };
+
+  const handleDeleteSeries = (seriesId: number) => {
+    if (!confirm("¿Eliminar este enfrentamiento?")) return;
+    deleteSeriesMutation.mutate(seriesId, {
+      onSuccess: () => toast.success("Enfrentamiento eliminado"),
+      onError: () =>
+        toast.error(
+          "No se pudo eliminar. Si tiene resultados cargados, eliminá el resultado primero."
+        ),
+    });
+  };
+
+  const handleDeleteFixture = () => {
+    if (
+      !confirm(
+        "¿Eliminar TODO el fixture? Se borrarán todos los enfrentamientos sin resultado."
+      )
+    )
+      return;
+    deleteFixtureMutation.mutate(undefined, {
+      onSuccess: () => toast.success("Fixture eliminado"),
+      onError: () => toast.error("Error al eliminar el fixture"),
     });
   };
 
@@ -34,23 +105,97 @@ export function FixtureTab({ event, categoryId, onSeriesClick }: FixtureTabProps
     return <p className="text-muted-foreground">Cargando fixture...</p>;
   }
 
+  const availableAwayTeams = teams.filter(
+    (t) => t.id.toString() !== homeTeamId
+  );
+
   return (
-    <div className="space-y-4">
-      {canGenerate && (
-        <Button
-          onClick={handleGenerate}
-          disabled={generateFixtureMutation.isPending}
-        >
-          <CalendarPlus className="h-4 w-4 mr-2" />
-          {generateFixtureMutation.isPending
-            ? "Generando..."
-            : "Generar fixture"}
-        </Button>
+    <div className="space-y-6">
+      {!isFinished && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Agregar enfrentamiento</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 md:grid-cols-4 items-end">
+              <div className="space-y-2">
+                <Label>Jornada</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={matchday}
+                  onChange={(e) => setMatchday(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Equipo local</Label>
+                <Select value={homeTeamId} onValueChange={(v) => {
+                  setHomeTeamId(v);
+                  if (v === awayTeamId) setAwayTeamId("");
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Seleccionar..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {teams.map((t) => (
+                      <SelectItem key={t.id} value={t.id.toString()}>
+                        {t.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Equipo visitante</Label>
+                <Select value={awayTeamId} onValueChange={setAwayTeamId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Seleccionar..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableAwayTeams.map((t) => (
+                      <SelectItem key={t.id} value={t.id.toString()}>
+                        {t.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                onClick={handleCreateSeries}
+                disabled={
+                  createSeriesMutation.isPending ||
+                  !homeTeamId ||
+                  !awayTeamId
+                }
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                {createSeriesMutation.isPending ? "Creando..." : "Agregar"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       )}
+
       <FixtureView
         series={series}
         onSeriesClick={onSeriesClick ? (s) => onSeriesClick(s.id) : undefined}
+        onDeleteSeries={!isFinished ? handleDeleteSeries : undefined}
       />
+
+      {series.length > 0 && !isFinished && (
+        <div className="pt-4 border-t">
+          <Button
+            variant="destructive"
+            onClick={handleDeleteFixture}
+            disabled={deleteFixtureMutation.isPending}
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            {deleteFixtureMutation.isPending
+              ? "Eliminando..."
+              : "Eliminar todo el fixture"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/sections/Team-Event/FixtureView.tsx
+++ b/src/sections/Team-Event/FixtureView.tsx
@@ -6,9 +6,10 @@ import { SeriesCard } from "./SeriesCard";
 interface FixtureViewProps {
   series: TeamEventSeries[];
   onSeriesClick?: (series: TeamEventSeries) => void;
+  onDeleteSeries?: (seriesId: number) => void;
 }
 
-export function FixtureView({ series, onSeriesClick }: FixtureViewProps) {
+export function FixtureView({ series, onSeriesClick, onDeleteSeries }: FixtureViewProps) {
   if (series.length === 0) {
     return (
       <p className="text-muted-foreground text-center py-8">
@@ -63,6 +64,7 @@ export function FixtureView({ series, onSeriesClick }: FixtureViewProps) {
                         onClick={
                           onSeriesClick ? () => onSeriesClick(s) : undefined
                         }
+                        onDelete={onDeleteSeries}
                       />
                     ))}
                   </div>
@@ -83,6 +85,7 @@ export function FixtureView({ series, onSeriesClick }: FixtureViewProps) {
                 onClick={
                   onSeriesClick ? () => onSeriesClick(s) : undefined
                 }
+                onDelete={onDeleteSeries}
               />
             ))}
           </div>

--- a/src/sections/Team-Event/SeriesCard.tsx
+++ b/src/sections/Team-Event/SeriesCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, Trash2 } from "lucide-react";
 import { TeamEventSeries, TeamEventMatch, TeamEventPlayer } from "@/types/Team-Event/TeamEvent";
 import {
   TeamEventSeriesStatus,
@@ -14,6 +15,7 @@ import {
 interface SeriesCardProps {
   series: TeamEventSeries;
   onClick?: () => void;
+  onDelete?: (seriesId: number) => void;
 }
 
 const statusLabels: Record<TeamEventSeriesStatus, string> = {
@@ -89,7 +91,7 @@ function renderMatchLine(match: TeamEventMatch) {
   );
 }
 
-export function SeriesCard({ series, onClick }: SeriesCardProps) {
+export function SeriesCard({ series, onClick, onDelete }: SeriesCardProps) {
   const isCompleted =
     series.status === TeamEventSeriesStatus.completed ||
     series.status === TeamEventSeriesStatus.walkover;
@@ -105,7 +107,7 @@ export function SeriesCard({ series, onClick }: SeriesCardProps) {
     >
       <CardContent className="p-4">
         <div className="flex items-center justify-between mb-2">
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center">
             {series.phase === TeamEventSeriesPhase.final && (
               <Badge variant="destructive">FINAL</Badge>
             )}
@@ -113,12 +115,27 @@ export function SeriesCard({ series, onClick }: SeriesCardProps) {
               {statusLabels[series.status]}
             </Badge>
           </div>
-          {series.phase === TeamEventSeriesPhase.regular && (
-            <span className="text-xs text-muted-foreground">
-              Jornada {series.matchday}
-              {series.roundNumber > 1 ? " (Vuelta)" : " (Ida)"}
-            </span>
-          )}
+          <div className="flex items-center gap-2">
+            {series.phase === TeamEventSeriesPhase.regular && (
+              <span className="text-xs text-muted-foreground">
+                Jornada {series.matchday}
+                {series.roundNumber > 1 ? " (Vuelta)" : " (Ida)"}
+              </span>
+            )}
+            {onDelete && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(series.id);
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5 text-destructive" />
+              </Button>
+            )}
+          </div>
         </div>
 
         <div className="flex items-center justify-between gap-4">

--- a/src/types/Team-Event/TeamEvent.ts
+++ b/src/types/Team-Event/TeamEvent.ts
@@ -219,3 +219,10 @@ export interface LoadMatchScoreRequest {
   homeTiebreakScore?: number;
   awayTiebreakScore?: number;
 }
+
+export interface CreateSeriesRequest {
+  homeTeamId: number;
+  awayTeamId: number;
+  matchday: number;
+  phase?: TeamEventSeriesPhase;
+}


### PR DESCRIPTION
## Summary
- Add manual fixture creation: admin can add matchups one by one (select matchday + home/away teams)
- Add delete tournament button in ConfigTab with confirmation dialog and redirect
- Add delete series button (Trash2) on each SeriesCard in admin fixture view
- Add delete entire fixture button
- Reset team selections when switching categories
- Invalidate event detail cache on deletion before redirect

## Backend PR
Companion PR in mirankingtenis.API: `feat/team-event-delete-modify` — adds `POST /series` endpoint for manual series creation

## Test plan
- [ ] Create tournament → create category → create teams → add matchups manually via fixture tab
- [ ] Verify matchday, home team, away team selectors work correctly
- [ ] Delete individual series from fixture view
- [ ] Delete entire fixture
- [ ] Delete tournament from ConfigTab → verify redirect to /admin/torneo-equipos
- [ ] Switch categories and verify team selectors reset
- [ ] Load lineup → load score → verify edit flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)